### PR TITLE
Update publish-docker to use actions to build

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,7 +7,9 @@ on:
     branches: [ master ]
 
 env:
-  DOCKER_TAG_IMAGE: "ghcr.io/dunkmann00/pages-gem"
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -17,18 +19,28 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get Docker Metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_TAG_IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build Docker Image
-        run: |
-          docker build -t ${{ steps.meta.outputs.tags }} -f Dockerfile .
-
-      - name: Push to Container Registry
-        if: github.event_name != 'pull_request'
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} https://ghcr.io --password-stdin
-          docker push ${{ steps.meta.outputs.tags }}
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.generate-image-tags.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This uses docker actions for building and pushing to the container registry rather than doing it with cli commands. This will address the issue where publishing from tags fails.