### PR TITLE
Change the name of the binary command

### DIFF
--- a/bin/jekyll-v4-github-pages
+++ b/bin/jekyll-v4-github-pages
@@ -3,10 +3,10 @@
 require 'mercenary'
 require_relative "../lib/github-pages"
 
-Mercenary.program(:"github-pages") do |p|
+Mercenary.program(:"jekyll-v4-github-pages") do |p|
   p.version GitHubPages::VERSION
   p.description
-  p.syntax "github-pages <subcommand> options"
+  p.syntax "jekyll-v4-github-pages <subcommand> options"
 
   p.command(:versions) do |c|
     c.syntax "versions"
@@ -30,9 +30,9 @@ Mercenary.program(:"github-pages") do |p|
     c.alias(:br)
     c.action do |args, options|
       puts [
-        "gem 'github-pages'",
+        "gem 'jekyll-v4-github-pages'",
         ":branch => '#{args[0] || "master"}'",
-        ":git => 'git://github.com/github/pages-gem'"
+        ":git => 'git://github.com/dunkmann00/pages-gem'"
       ].join(", ")
     end
   end

--- a/contrib/func.sh
+++ b/contrib/func.sh
@@ -2,7 +2,7 @@
 # The github-pages function optionally takes two arguments
 #  - the first argument is the path to the Jekyll site
 #  - the second argument is the port number
-function github-pages {
+function jekyll-v4-github-pages {
   _path=${1:-.}
   _port=${2:-4000}
   docker run --rm \

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -181,7 +181,7 @@ module GitHubPages
       # Print the versions for github-pages and jekyll to the debug
       # stream for debugging purposes. See by running Jekyll with '--verbose'
       def debug_print_versions
-        Jekyll.logger.debug "GitHub Pages:", "github-pages v#{GitHubPages::VERSION}"
+        Jekyll.logger.debug "GitHub Pages:", "jekyll-v4-github-pages v#{GitHubPages::VERSION}"
         Jekyll.logger.debug "GitHub Pages:", "jekyll v#{Jekyll::VERSION}"
       end
     end

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -66,7 +66,7 @@ module GitHubPages
         "ruby" => RUBY_VERSION,
 
         # Gem versions we're curious about
-        "github-pages" => VERSION.to_s,
+        "jekyll-v4-github-pages" => VERSION.to_s,
         "html-pipeline" => HTML::Pipeline::VERSION,
         "sass" => Sass::Embedded::VERSION,
         "safe_yaml" => SafeYAML::VERSION,

--- a/script/cibuild-docker
+++ b/script/cibuild-docker
@@ -5,5 +5,5 @@ set -ex
 # Set the ruby version in the Action definition matrix.
 : "${RUBY_VERSION:="3.1.2"}"
 
-docker build --build-arg "RUBY_VERSION=$RUBY_VERSION" -t github-pages .
-docker run --rm --workdir /src/gh/pages-gem --env "JEKYLL_GITHUB_TOKEN=$JEKYLL_GITHUB_TOKEN" github-pages script/cibuild
+docker build --build-arg "RUBY_VERSION=$RUBY_VERSION" -t jekyll-v4-github-pages .
+docker run --rm --workdir /src/gh/pages-gem --env "JEKYLL_GITHUB_TOKEN=$JEKYLL_GITHUB_TOKEN" jekyll-v4-github-pages script/cibuild

--- a/script/test-site
+++ b/script/test-site
@@ -12,7 +12,7 @@ export BUNDLE_GEMFILE
 cd test-site
 rm -Rf Gemfile
 
-echo "Using $(bundle exec github-pages --version)"
+echo "Using $(bundle exec jekyll-v4-github-pages --version)"
 echo "Using $(bundle exec jekyll --version)"
 bundle exec jekyll build --trace --verbose
 

--- a/spec/github-pages/bin_spec.rb
+++ b/spec/github-pages/bin_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe(GitHubPages) do
   it "lists the dependency versions" do
-    output = `github-pages versions`
+    output = `jekyll-v4-github-pages versions`
     expect(output).to include("Gem")
     expect(output).to include("Version")
     GitHubPages::Dependencies.gems.each do |name, version|
@@ -14,12 +14,12 @@ describe(GitHubPages) do
   end
 
   it "outputs the branch" do
-    expect(`./bin/github-pages branch`).to eql("gem 'github-pages', :branch => 'master', :git => 'git://github.com/github/pages-gem'\n")
+    expect(`./bin/jekyll-v4-github-pages branch`).to eql("gem 'jekyll-v4-github-pages', :branch => 'master', :git => 'git://github.com/dunkmann00/pages-gem'\n")
   end
 
   it "detects the CNAME when running health check" do
     File.write("CNAME", "foo.invalid")
-    expect(`./bin/github-pages health-check --trace`).to include("Checking domain foo.invalid...")
+    expect(`./bin/jekyll-v4-github-pages health-check --trace`).to include("Checking domain foo.invalid...")
     File.delete("CNAME")
   end
 end

--- a/spec/github-pages/dependencies_spec.rb
+++ b/spec/github-pages/dependencies_spec.rb
@@ -16,7 +16,7 @@ describe(GitHubPages::Dependencies) do
   it "exposes relevant versions of dependencies, self and Ruby" do
     expect(described_class.versions).to be_a(Hash)
     expect(described_class.versions).to include("ruby")
-    expect(described_class.versions).to include("github-pages")
+    expect(described_class.versions).to include("jekyll-v4-github-pages")
   end
 
   context "jekyll core dependencies" do


### PR DESCRIPTION
When actually using this fork I found that by having the same bin command name creates a conflict. There is an overlap and the way bundler handles it, one of the forks will get hidden behind the other. This changes the name of the command in bin so that problem won't happen.