### PR TITLE
Add a jekyll site to build with GH Pages

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -1,0 +1,61 @@
+# Workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs schedule
+  schedule:
+    - cron: "0 0 * * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          ruby-version: "3.1" # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --source site
+        env:
+          JEKYLL_ENV: production
+          JEKYLL_GITHUB_TOKEN: ${{ github.token }}
+          PAGES_REPO_NWO: ${{ github.repository }}
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v1
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ CNAME
 test-site/
 vendor/
 tmp/
+_site/
+.jekyll-cache

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,11 +126,20 @@ Metrics/MethodLength:
 Style/Alias:
   Enabled: false # We have no guidance on alias vs alias_method
 
+Style/MapToSet:
+  Enabled: true
+
+Style/MinMaxComparison:
+  Enabled: true
+
 Style/RedundantSelf:
   Enabled: false # Sometimes a self.field is a bit more clear
 
 Style/IfUnlessModifier:
   Enabled: false
+
+Style/YodaExpression:
+  Enabled: true
 
 Naming/FileName: #Rubocop doesn't like the Git*H*ub namespace
   Enabled: false

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,0 +1,8 @@
+theme: jekyll-v4-theme-primer
+
+primer:
+  theme: auto
+
+title: Pages - Jekyll v4
+description: A simple Ruby Gem to bootstrap dependencies for setting up and
+  maintaining a local Jekyll v4 environment similar to GitHub Pages.

--- a/site/_plugins/deps.rb
+++ b/site/_plugins/deps.rb
@@ -1,0 +1,3 @@
+Jekyll::Hooks.register :site, :after_init do |site|
+  site.config["dependencies"] = GitHubPages::Dependencies.gems
+end

--- a/site/_plugins/deps.rb
+++ b/site/_plugins/deps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Jekyll::Hooks.register :site, :after_init do |site|
   site.config["dependencies"] = GitHubPages::Dependencies.gems
 end

--- a/site/assets/css/style.scss
+++ b/site/assets/css/style.scss
@@ -1,0 +1,32 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.markdown-body h1 {
+  text-align: center;
+  font-size: 48px;
+  font-weight: 200;
+}
+
+.markdown-body h2 {
+  text-align: center;
+  font-size: 21px;
+  font-weight: 200;
+}
+
+.markdown-body table {
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 25px;
+  font-size: 1.2em;
+}
+
+.markdown-body table th, .markdown-body table td, .markdown-body table tr {
+  border: none;
+  text-align: left;
+}
+
+.markdown-body {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}

--- a/site/versions.json
+++ b/site/versions.json
@@ -1,0 +1,3 @@
+---
+---
+{{ site.dependencies | jsonify }}

--- a/site/versions/index.md
+++ b/site/versions/index.md
@@ -1,0 +1,25 @@
+---
+title: Pages - Jekyll v4
+layout: default
+---
+# {{ page.title }}
+
+# Dependency versions
+
+## The fork of GitHub Pages uses the following dependencies and versions:
+
+|Dependency|Version|
+|----------|-------|
+{%- for dependency in site.dependencies %}
+| [{{ dependency[0] }}](https://rubygems.org/gems/{{ dependency[0] }}/versions/{{ dependency[1] }}) | {{ dependency[1] }} |
+{%- endfor %}
+
+For a history of dependency changes, see [the past releases](https://github.com/dunkmann00/pages-gem/releases).
+
+## Programmatic access
+
+Want a more programmatic way to keep your local version of Jekyll up to date?
+All dependencies are bundled within the GitHub Pages Ruby gem, or are available
+programmatically via [www.georgeh2os.com/pages-gem/versions.json](https://www.georgeh2os.com/pages-gem/versions.json)
+
+Last updated {{ "now" | date: "%Y-%m-%d %I%P %z" }}


### PR DESCRIPTION
This site will show the versions of all the dependencies that the current version of this repo are using. It is the same thing as pages.github.com/versions/ and similar to that site, also has a json render of the dependencies.

This will be built with GH Actions using a workflow. In keeping it similar to the actual GitHub Pages versions site, I think I will have the workflow build the site with a cron job that runs daily. I also think it makes the most sense to have it build the latest *release*, not the latest *commit* from master.

Closes #12 