### PR TITLE
Build versions site with latest tag

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -26,8 +26,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (All History)
         uses: actions/checkout@v3
+        with:
+          # Since this repo isn't very big, this is trivial.
+          fetch-depth: 0
+      - name: Get Latest Tag
+        run: echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> ${{ github.env }}
+        # Alternate way to get the latest tag (Doesn't require 'fetch-depth: 0')
+        # run: echo "LATEST_TAG=v$(grep 'VERSION' lib/github-pages/version.rb | awk '{print $3}')" >> ${{ github.env }}
+      - name: Checkout (Latest Release Tag)
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.LATEST_TAG }}
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:


### PR DESCRIPTION
This should checkout the latest tag rather than the latest commit from master. This way, the versions site will get built daily, so the "Last Updated" text will reflect it is up-to-date, but it will reflect the dependencies that are set in the latest release.