### PR TITLE
Don't schedule right at UTC midnight

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -4,7 +4,7 @@ name: Deploy Jekyll site to Pages
 on:
   # Runs schedule
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "32 0 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The initial run was delayed over an hour. I don't know if scheduling it only 32 minutes later will make any difference, but I'll give it a try and see what happens.