### PR TITLE
Switch to using jekyll-v4-gh-pages to build pages site

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -22,51 +22,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build job
-  build:
+  gh_pages:
+    name: Build & Deploy Github Pages
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout (All History)
+      - name: Checkout
         uses: actions/checkout@v3
+      - name: Build & Deploy
+        uses: dunkmann00/jekyll-v4-gh-pages@v1
         with:
-          # Since this repo isn't very big, this is trivial.
-          fetch-depth: 0
-      - name: Get Latest Tag
-        run: echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> ${{ github.env }}
-        # Alternate way to get the latest tag (Doesn't require 'fetch-depth: 0')
-        # run: echo "LATEST_TAG=v$(grep 'VERSION' lib/github-pages/version.rb | awk '{print $3}')" >> ${{ github.env }}
-      - name: Checkout (Latest Release Tag)
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.LATEST_TAG }}
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
-        with:
-          ruby-version: "3.1" # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v3
-      - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --source site
-        env:
-          JEKYLL_ENV: production
-          JEKYLL_GITHUB_TOKEN: ${{ github.token }}
-          PAGES_REPO_NWO: ${{ github.repository }}
-      - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
-
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+          source: site

--- a/bin/jekyll-v4-github-pages
+++ b/bin/jekyll-v4-github-pages
@@ -65,8 +65,21 @@ Mercenary.program(:"jekyll-v4-github-pages") do |p|
     c.option 'source', '--source DIR', 'From where to collect the source files'
     c.option 'destination', '--destination DIR', 'To where the compiled files should be written'
     c.option 'future', '--future', 'Publishes posts with a future date'
+    c.option 'config', '--config FILE1[,FILE2[,FILE3]]', Array, 'Specify config files instead of using _config.yml'
 
     c.action do |_, options|
+      config = options["config"] || ["_config.yml"]
+
+      default_config = File.expand_path("../../lib/_default_config.yml", __FILE__)
+      options["config"] = [default_config]
+
+      config.each { |item|
+        user_config = File.join(options["source"] || Dir.pwd, item)
+        if File.exist?(user_config)
+          options["config"].push(user_config)
+        end
+      }
+      
       Jekyll::Commands::Build.process(options)
     end
   end

--- a/lib/_default_config.yml
+++ b/lib/_default_config.yml
@@ -1,0 +1,21 @@
+# Default, user overwritable options
+jailed: false
+future: true
+theme: jekyll-v4-theme-primer
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+  gfm_quirks: paragraph_end
+  syntax_highlighter_opts:
+    default_lang: plaintext
+  template: ""
+  math_engine: mathjax
+  syntax_highlighter: rouge
+
+# Previously not overwritable, now these can be configured as well
+lsi: false
+safe: true
+highlighter: rouge
+gist:
+  noscript: false

--- a/lib/_default_config.yml
+++ b/lib/_default_config.yml
@@ -12,6 +12,8 @@ kramdown:
   template: ""
   math_engine: mathjax
   syntax_highlighter: rouge
+exclude:
+  - CNAME
 
 # Previously not overwritable, now these can be configured as well
 lsi: false

--- a/lib/_default_config.yml
+++ b/lib/_default_config.yml
@@ -1,6 +1,6 @@
 # Default, user overwritable options
 jailed: false
-future: true
+future: false
 theme: jekyll-v4-theme-primer
 markdown: kramdown
 kramdown:

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -18,3 +18,5 @@ end
 Jekyll::Hooks.register :site, :after_reset do |site|
   GitHubPages::Configuration.set(site)
 end
+
+Jekyll::Configuration::DEFAULTS = Jekyll::Utils.deep_merge_hashes Jekyll::Configuration::DEFAULTS, GitHubPages::Configuration::DEFAULTS

--- a/lib/github-pages.rb
+++ b/lib/github-pages.rb
@@ -18,5 +18,3 @@ end
 Jekyll::Hooks.register :site, :after_reset do |site|
   GitHubPages::Configuration.set(site)
 end
-
-Jekyll::Configuration::DEFAULTS = Jekyll::Utils.deep_merge_hashes Jekyll::Configuration::DEFAULTS, GitHubPages::Configuration::DEFAULTS

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -3,7 +3,7 @@
 require "securerandom"
 
 module GitHubPages
-  # Sets and manages Jekyll configuration defaults and overrides
+  # Sets and manages Jekyll configuration defaults
   class Configuration
     # Backward compatability of constants
     DEFAULT_PLUGINS     = GitHubPages::Plugins::DEFAULT_PLUGINS
@@ -25,40 +25,26 @@ module GitHubPages
         "syntax_highlighter_opts" => {
           "default_lang" => "plaintext",
         },
+        "template" => "",
+        "math_engine" => "mathjax",
+        "syntax_highlighter" => "rouge",
       },
       "exclude" => ["CNAME"],
+
+      # Previously not overwritable, now these can be configured as well
+      "lsi" => false,
+      "safe" => true,
+      "whitelist" => GitHubPages::Plugins::PLUGIN_WHITELIST,
+      "highlighter" => "rouge",
+      "gist" => {
+        "noscript" => false,
+      },
     }.freeze
 
     # User-overwritable defaults used only in production for practical reasons
     PRODUCTION_DEFAULTS = Jekyll::Utils.deep_merge_hashes DEFAULTS, {
       "sass" => {
         "style" => "compressed",
-      },
-    }.freeze
-
-    # Options which GitHub Pages sets, regardless of the user-specified value
-    #
-    # The following values are also overridden by GitHub Pages, but are not
-    # overridden locally, for practical purposes:
-    # * source
-    # * destination
-    # * jailed
-    # * verbose
-    # * incremental
-    # * GH_ENV
-    OVERRIDES = {
-      "lsi" => false,
-      "safe" => true,
-      "plugins_dir" => SecureRandom.hex,
-      "whitelist" => GitHubPages::Plugins::PLUGIN_WHITELIST,
-      "highlighter" => "rouge",
-      "kramdown" => {
-        "template" => "",
-        "math_engine" => "mathjax",
-        "syntax_highlighter" => "rouge",
-      },
-      "gist" => {
-        "noscript" => false,
       },
     }.freeze
 
@@ -79,31 +65,20 @@ module GitHubPages
         Jekyll.env == "development"
       end
 
-      def defaults_for_env
-        defaults = development? ? DEFAULTS : PRODUCTION_DEFAULTS
-        Jekyll::Utils.deep_merge_hashes Jekyll::Configuration::DEFAULTS, defaults
-      end
-
-      # Given a user's config, determines the effective configuration by building a user
-      # configuration sandwhich with our overrides overriding the user's specified
-      # values which themselves override our defaults.
-      #
       # Returns the effective Configuration
       #
       # Note: this is a highly modified version of Jekyll#configuration
       def effective_config(user_config)
-        # Merge user config into defaults
-        config = Jekyll::Utils.deep_merge_hashes(defaults_for_env, user_config)
-          .add_default_collections
+        config = user_config
+        if !development?
+          config = Jekyll::Utils.deep_merge_hashes PRODUCTION_DEFAULTS, config
+        end
 
         # Allow theme to be explicitly disabled via "theme: null"
         config["theme"] = user_config["theme"] if user_config.key?("theme")
 
         migrate_theme_to_remote_theme(config)
         exclude_cname(config)
-
-        # Merge overwrites into user config
-        config = Jekyll::Utils.deep_merge_hashes config, OVERRIDES
 
         restrict_and_config_markdown_processor(config)
 
@@ -123,7 +98,7 @@ module GitHubPages
         processed(site)
       end
 
-      # Set the site's configuration with all the proper defaults and overrides.
+      # Set the site's configuration with all the proper defaults.
       # Should be called by #set to protect against multiple processings.
       def set!(site)
         site.config = effective_config(site.config)

--- a/lib/github-pages/configuration.rb
+++ b/lib/github-pages/configuration.rb
@@ -62,9 +62,6 @@ module GitHubPages
           config = Jekyll::Utils.deep_merge_hashes PRODUCTION_DEFAULTS, config
         end
 
-        puts "Safe:"
-        puts config["safe"]
-
         # Allow theme to be explicitly disabled via "theme: null"
         config["theme"] = user_config["theme"] if user_config.key?("theme")
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -6,3 +6,5 @@ primer:
 title: Pages - Jekyll v4
 description: A simple Ruby Gem to bootstrap dependencies for setting up and
   maintaining a local Jekyll v4 environment similar to GitHub Pages.
+
+safe: false

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,5 +1,4 @@
 some_key: some_value
-safe: false
 plugins:
   - jekyll-sitemap
   - jekyll-redirect-from

--- a/spec/fixtures/_config_with_gfm.yml
+++ b/spec/fixtures/_config_with_gfm.yml
@@ -1,6 +1,5 @@
 markdown: GFM
 some_key: some_value
-safe: false
 plugins:
   - jekyll-sitemap
   - jekyll-redirect-from

--- a/spec/fixtures/_config_with_remote_theme.yml
+++ b/spec/fixtures/_config_with_remote_theme.yml
@@ -1,5 +1,4 @@
 some_key: some_value
-safe: false
 plugins:
   - jekyll-sitemap
   - jekyll-redirect-from

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -9,6 +9,7 @@ describe(GitHubPages::Configuration) do
       "quiet" => true,
       "testing" => "123",
       "destination" => tmp_dir,
+      "config" => ["lib/_default_config.yml", File.join(fixture_dir, "_config.yml")],
     }
   end
   let(:configuration) { Jekyll.configuration(test_config) }
@@ -173,6 +174,7 @@ describe(GitHubPages::Configuration) do
         "testing" => "123",
         "destination" => tmp_dir,
         "future" => true,
+        "config" => ["lib/_default_config.yml", File.join(fixture_dir, "_config.yml")],
       }
     end
 

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -14,7 +14,6 @@ describe(GitHubPages::Configuration) do
   let(:configuration) { Jekyll.configuration(test_config) }
   let(:site)          { Jekyll::Site.new(configuration) }
   let(:effective_config) { described_class.effective_config(site.config) }
-  let(:defaults_for_env) { described_class.defaults_for_env }
 
   before(:each) do
     ENV.delete("DISABLE_WHITELIST")
@@ -25,7 +24,7 @@ describe(GitHubPages::Configuration) do
   context "#effective_config" do
     it "sets configuration defaults" do
       expect(effective_config["kramdown"]["input"]).to eql("GFM")
-      expect(effective_config["future"]).to eql(false)
+      expect(effective_config["future"]).to eql(true)
     end
 
     it "sets default gems" do
@@ -44,7 +43,7 @@ describe(GitHubPages::Configuration) do
       expect(effective_config["highlighter"]).to eql("rouge")
     end
 
-    it "overrides user's values" do
+    it "doesn't override user's values" do
       expect(effective_config["safe"]).to eql(true)
       expect(effective_config["quiet"]).to eql(true)
     end
@@ -162,7 +161,6 @@ describe(GitHubPages::Configuration) do
 
       it "doesn't compress sass" do
         expect(effective_config["sass"]).to be_nil
-        expect(defaults_for_env["sass"]).to be_nil
       end
     end
   end
@@ -199,7 +197,7 @@ describe(GitHubPages::Configuration) do
       expect(site.config["highlighter"]).to eql("rouge")
     end
 
-    it "overrides user's values" do
+    it "doesn't override user's values" do
       expect(site.config["safe"]).to eql(true)
       expect(site.config["quiet"]).to eql(true)
     end
@@ -272,7 +270,6 @@ describe(GitHubPages::Configuration) do
 
       it "compresses sass" do
         expect(effective_config["sass"]).to eql("style" => "compressed")
-        expect(defaults_for_env["sass"]).to eql("style" => "compressed")
       end
     end
   end

--- a/spec/github-pages/configuration_spec.rb
+++ b/spec/github-pages/configuration_spec.rb
@@ -25,7 +25,7 @@ describe(GitHubPages::Configuration) do
   context "#effective_config" do
     it "sets configuration defaults" do
       expect(effective_config["kramdown"]["input"]).to eql("GFM")
-      expect(effective_config["future"]).to eql(true)
+      expect(effective_config["future"]).to eql(false)
     end
 
     it "sets default gems" do

--- a/spec/github-pages/integration_spec.rb
+++ b/spec/github-pages/integration_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Pages Gem Integration spec" do
 
   def build(additional_flags = nil)
     Dir.chdir(source) do
-      cmd = %w(bundle exec jekyll build --verbose --trace)
+      cmd = %w(../../bin/jekyll-v4-github-pages build --verbose)
       cmd = cmd.concat ["--source", source, "--destination", destination]
       cmd = cmd.concat(additional_flags) if additional_flags
       run_cmd(cmd)


### PR DESCRIPTION
I'm testing this out to see if building the site with the action pulls the dependencies from the `GitHubPages` from the docker image and not from this repo. I would prefer that, as it is kind of more *correct* with respect to 'Pages - Jekyll v4' since ultimately the build action needs to be updated for things to build with the newest `pages-gem` dependencies.

It also gets rid of the complexity of having to select the correct tag.