### PR TITLE
Switch site deploy back to midnight UTC

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -4,7 +4,7 @@ name: Deploy Jekyll site to Pages
 on:
   # Runs schedule
   schedule:
-    - cron: "32 0 * * *"
+    - cron: "0 0 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Changing it didn't help, just made it run even later. So lets just put it back to midnight and live with the delay.