### PR TITLE
Improve github-pages build command

### DIFF
--- a/bin/jekyll-v4-github-pages
+++ b/bin/jekyll-v4-github-pages
@@ -68,18 +68,14 @@ Mercenary.program(:"jekyll-v4-github-pages") do |p|
     c.option 'config', '--config FILE1[,FILE2[,FILE3]]', Array, 'Specify config files instead of using _config.yml'
 
     c.action do |_, options|
-      config = options["config"] || ["_config.yml"]
+      Jekyll.logger.log_level = :error
+      user_configs = Jekyll::Configuration.new.config_files(options.except("verbose"))
+      Jekyll.logger.log_level = :info
 
       default_config = File.expand_path("../../lib/_default_config.yml", __FILE__)
-      options["config"] = [default_config]
 
-      config.each { |item|
-        user_config = File.join(options["source"] || Dir.pwd, item)
-        if File.exist?(user_config)
-          options["config"].push(user_config)
-        end
-      }
-      
+      options["config"] = [default_config] + user_configs
+
       Jekyll::Commands::Build.process(options)
     end
   end

--- a/bin/jekyll-v4-github-pages
+++ b/bin/jekyll-v4-github-pages
@@ -69,7 +69,9 @@ Mercenary.program(:"jekyll-v4-github-pages") do |p|
 
     c.action do |_, options|
       Jekyll.logger.log_level = :error
-      user_configs = Jekyll::Configuration.new.config_files(options.except("verbose"))
+      config_options = options.clone
+      config_options.delete("verbose")
+      user_configs = Jekyll::Configuration.new.config_files(config_options)
       Jekyll.logger.log_level = :info
 
       default_config = File.expand_path("../../lib/_default_config.yml", __FILE__)


### PR DESCRIPTION
This both simplifies the code used in the build command and improves it. This is accomplished by reusing the code from within Jekyll that processes which config files are used.

There are two big changes to this. The first is a bugfix. When including a config file via cli argument, no source path is added onto it. This behavior should not have been changed since this is not how it would normally work via the cli. The second change is that config files with `yaml` or `toml` extensions will now be discovered as user default config files if they are present. This again, is exactly how it works normally with Jekyll.