### PR TITLE
Don't include _config.yml when it doesn't exist

### DIFF
--- a/bin/jekyll-v4-github-pages
+++ b/bin/jekyll-v4-github-pages
@@ -75,6 +75,7 @@ Mercenary.program(:"jekyll-v4-github-pages") do |p|
       Jekyll.logger.log_level = :info
 
       default_config = File.expand_path("../../lib/_default_config.yml", __FILE__)
+      user_configs = user_configs.select { |config| File.exist?(config) }
 
       options["config"] = [default_config] + user_configs
 


### PR DESCRIPTION
The way this is intended to work is the same as GitHub's where you don't need to include a `_config.yml`. Thats kind of the whole point so not sure how I missed this. But this fixes this and makes sure any user defined configs or the Jekyll default of `_config.yml`, exist before passing it along.