### PR TITLE
Prepare for new release

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-# Whitelisted plugins not included in runtime dependencies.
-gem "jekyll-octicons"
-
 group :test do
   gem "rubocop", "~> 1.41"
   gem "rubocop-performance"

--- a/lib/github-pages/dependencies.rb
+++ b/lib/github-pages/dependencies.rb
@@ -17,7 +17,7 @@ module GitHubPages
 
       # Misc
       "liquid" => "4.0.4",
-      "rouge" => "4.2",
+      "rouge" => "4.2.1",
       "github-pages-health-check" => "1.18.2",
 
       # Plugins
@@ -32,6 +32,7 @@ module GitHubPages
       "jekyll-avatar" => "0.8.0",
       "jekyll-remote-theme" => "0.4.3",
       "jekyll-include-cache" => "0.2.1",
+      "jekyll-octicons" => "19.8.0",
 
       # Plugins to match GitHub.com Markdown
       "jemoji" => "0.13.0",

--- a/lib/github-pages/plugins.rb
+++ b/lib/github-pages/plugins.rb
@@ -14,6 +14,7 @@ module GitHubPages
       jekyll-readme-index
       jekyll-default-layout
       jekyll-titles-from-headings
+      jekyll-octicons
     ).freeze
 
     # Plugins allowed by GitHub Pages
@@ -49,7 +50,7 @@ module GitHubPages
       "minima" => "2.5.1",
       "jekyll-swiss" => "1.0.0",
       "jekyll-theme-primer" => "0.6.0",
-      "jekyll-v4-theme-primer" => "0.12.0",
+      "jekyll-v4-theme-primer" => "0.14.0",
       "jekyll-theme-architect" => "0.2.0",
       "jekyll-theme-cayman" => "0.2.0",
       "jekyll-theme-dinky" => "0.2.0",
@@ -68,7 +69,7 @@ module GitHubPages
     THEMES_TO_CONVERT_TO_REMOTE_THEMES = {
       "jekyll-swiss" => "broccolini/swiss",
       "jekyll-theme-primer" => "pages-themes/primer@v0.6.0",
-      "jekyll-v4-theme-primer" => "dunkmann00/primer@v0.9.0",
+      "jekyll-v4-theme-primer" => "dunkmann00/primer@v0.14.0",
       "jekyll-theme-architect" => "pages-themes/architect@v0.2.0",
       "jekyll-theme-cayman" => "pages-themes/cayman@v0.2.0",
       "jekyll-theme-dinky" => "pages-themes/dinky@v0.2.0",

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHubPages
-  VERSION = 236
+  VERSION = 237
 end

--- a/spec/github-pages/plugins_spec.rb
+++ b/spec/github-pages/plugins_spec.rb
@@ -14,9 +14,6 @@ describe(GitHubPages::Plugins) do
   context "versions all whitelisted plugins" do
     GitHubPages::Plugins::PLUGIN_WHITELIST.each do |plugin|
       it "versions the #{plugin} plugin" do
-        next if plugin == "jekyll-include-cache"
-        next if plugin == "jekyll-octicons" # TODO: we should expose the version for these
-
         expect(GitHubPages::Dependencies::VERSIONS.keys).to include(plugin)
       end
     end


### PR DESCRIPTION
This PR includes a few updates:
- Add `setup-buildx-action` to docker workflow
- Add `jekyll-octicons` dependency & bump `rouge`
- Bump 💎 to v237

More info about the thinking behind adding `jekyll-octicons`:

Adds `jekyll-octicons` as a default dependency of pages-gem. It was being added later on in the github pages chain of tools so it was available, but just not from here in pages-gem. It seems the intent there *might* have been to not pin octicons down to a specific version, therefore making it easier to get the latest versions. This seems to have failed, given it was pinned to 14.x while they are now up to 19.x. Not sure where it was when I forked this, but still, definitely wasn't on the latest major version.